### PR TITLE
fix(listeners): fix a regression in the inferring of listener names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 .vscode
 .mypy_cache
+*.egg-info/
 *env*/
 
 test.py

--- a/disnake_ext_components/listener.py
+++ b/disnake_ext_components/listener.py
@@ -249,6 +249,7 @@ class ButtonListener(abc.BaseListener[P, T, disnake.MessageInteraction]):
 
 def button_listener(
     *,
+    name: t.Optional[str] = None,
     regex: t.Union[str, t.Pattern[str], None] = None,
     sep: str = ":",
     bot: t.Optional[commands.Bot] = None,
@@ -287,7 +288,13 @@ def button_listener(
     def wrapper(
         func: ButtonListenerCallback[ParentT, P, T],
     ) -> ButtonListener[P, T]:
-        listener = ButtonListener[P, T](func, regex=regex, sep=sep, reference=reference)
+        listener = ButtonListener[P, T](
+            func,
+            name=func.__name__ if name is None else name,
+            regex=regex,
+            sep=sep,
+            reference=reference,
+        )
 
         if bot is not None:
             bot.add_listener(listener, types_.ListenerType.BUTTON)
@@ -518,6 +525,7 @@ class SelectListener(abc.BaseListener[P, T, disnake.MessageInteraction]):
 
 def select_listener(
     *,
+    name: t.Optional[str] = None,
     regex: t.Union[str, t.Pattern[str], None] = None,
     sep: str = ":",
     bot: t.Optional[commands.Bot] = None,
@@ -560,7 +568,13 @@ def select_listener(
     def wrapper(
         func: SelectListenerCallback[ParentT, P, T],
     ) -> SelectListener[P, T]:
-        listener = SelectListener[P, T](func, regex=regex, sep=sep, reference=reference)
+        listener = SelectListener[P, T](
+            func,
+            name=func.__name__ if name is None else name,
+            regex=regex,
+            sep=sep,
+            reference=reference,
+        )
 
         if bot is not None:
             bot.add_listener(listener, types_.ListenerType.SELECT)
@@ -736,6 +750,7 @@ class ModalListener(abc.BaseListener[P, T, disnake.ModalInteraction]):
 
 def modal_listener(
     *,
+    name: t.Optional[str] = None,
     regex: t.Union[str, t.Pattern[str], None] = None,
     sep: str = ":",
     bot: t.Optional[commands.Bot] = None,
@@ -799,7 +814,12 @@ def modal_listener(
     def wrapper(
         func: ModalListenerCallback[ParentT, P, T],
     ) -> ModalListener[P, T]:
-        listener = ModalListener(func, regex=regex, sep=sep)
+        listener = ModalListener[P, T](
+            func,
+            name=func.__name__ if name is None else name,
+            regex=regex,
+            sep=sep,
+        )
 
         if bot is not None:
             bot.add_listener(listener, types_.ListenerType.MODAL)

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -8,7 +8,6 @@ import pytest
 import disnake_ext_components as components
 from disnake_ext_components import abc
 
-
 # The decorated function...
 ListenerCallback = t.Callable[..., t.Any]
 
@@ -36,7 +35,7 @@ def test_listener_name_default(listener_decorator: ListenerBuilder):
 
 
 def test_listener_name_default_modal():
-    # Modals need a ModalInteraction and at least one textinput field... 
+    # Modals need a ModalInteraction and at least one textinput field...
 
     @components.modal_listener()
     async def callback(inter: disnake.ModalInteraction, field1: str):

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -1,0 +1,79 @@
+# TODO: Add more tests to ensure proper functionality before pypi release!
+
+import typing as t
+
+import disnake
+import pytest
+
+import disnake_ext_components as components
+from disnake_ext_components import abc
+
+
+# The decorated function...
+ListenerCallback = t.Callable[..., t.Any]
+
+# The return type of the wrapped decorator...
+# (callable that should take the decorated func and return a listener)
+WrappedCallback = t.Callable[[ListenerCallback], abc.BaseListener[t.Any, t.Any, t.Any]]
+
+# The decorator itself...
+# (callable that should take args, then return the above decorator)
+ListenerBuilder = t.Callable[..., WrappedCallback]
+
+
+@pytest.mark.parametrize(
+    "listener_decorator",
+    [components.button_listener, components.select_listener],
+)
+def test_listener_name_default(listener_decorator: ListenerBuilder):
+    # Simple listeners should infer their name from the callback by default...
+
+    @listener_decorator()
+    async def callback(inter: disnake.MessageInteraction):
+        pass
+
+    assert callback.name == "callback"
+
+
+def test_listener_name_default_modal():
+    # Modals need a ModalInteraction and at least one textinput field... 
+
+    @components.modal_listener()
+    async def callback(inter: disnake.ModalInteraction, field1: str):
+        pass
+
+    assert callback.name == "callback"
+
+
+@pytest.mark.parametrize(
+    "listener_decorator",
+    [components.button_listener, components.select_listener],
+)
+def test_listener_name_override(listener_decorator: ListenerBuilder):
+
+    override = "make_sure_this_is_overwritten"
+
+    @listener_decorator(name=override)
+    async def this_should_not_show_up(inter: disnake.MessageInteraction):
+        pass
+
+    assert this_should_not_show_up.name == override
+
+
+def test_listener_name_override_modal():
+
+    override = "make_sure_this_is_overwritten"
+
+    @components.modal_listener(name=override)
+    async def this_should_not_show_up(inter: disnake.ModalInteraction, field1: str):
+        pass
+
+    assert this_should_not_show_up.name == override
+
+
+# TODO: Add tests for match_component naming, though that needs some further work.
+#       Currently, they allow not specifying a name at all, which I doubt actually
+#       offers any useful functionality, and also caused the naming regression.
+#
+#       I will therefore probably end up slightly reworking match_component first,
+#       before continuing with these tests.


### PR DESCRIPTION
This regression was caused by #5, where the `match_component` decorator was added with the ability to not provide a name.

This PR fixes an issue with the `button_listener`, `select_listener`, and `modal_listener` decorators. Instead of inferring the name of the callback they were decorating, and using that as a base with which to create custom ids, they would leave the name field of the underlying listener objects blank. This would lead to conflicts in case multiple components with different listeners were created with the same parameters.

Instead, I will probably look to change the way `match_component` listeners handle components' custom ids at a later date.

Furthermore, this PR adds the ability to set a custom name to use instead of the callback name, through the `name` kwarg on the affected decorators.