### PR TITLE
fix: regression caused by new select types

### DIFF
--- a/disnake_ext_components/listener.py
+++ b/disnake_ext_components/listener.py
@@ -882,7 +882,6 @@ def match_component(
     max_values: int = ...,
     disabled: bool = ...,
     options: t.List[disnake.SelectOption] = ...,
-    label: str = ...,
     bot: t.Optional[commands.Bot] = None,
 ) -> t.Callable[[SelectListenerCallback[ParentT, P, T]], SelectListener[P, T]]:
     ...

--- a/disnake_ext_components/types_.py
+++ b/disnake_ext_components/types_.py
@@ -201,6 +201,7 @@ class AbstractComponent:
     __slots__: t.Tuple[t.Any] = tuple(
         set(disnake.Component.__slots__)
         | set(disnake.Button.__slots__)
+        | set(disnake.BaseSelectMenu.__slots__)
         | set(disnake.SelectMenu.__slots__)
     )
 


### PR DESCRIPTION
With the split from `disnake.SelectMenu` into `disnake.BaseSelectMenu`/`disnake.StringSelectMenu`/etc., the slots stored on each individual type were changed, which broke the logic in AbstractComponent. This, in turn, broke the `match_component` tool.

Aside from that, this fixes a small typehinting issue in `match_component` itself.