### PR TITLE
feat!: implement all select types

### DIFF
--- a/examples/select.py
+++ b/examples/select.py
@@ -57,7 +57,7 @@ COLOUR_OPTIONS = [
 ]
 
 # Then, we make the select.
-class MySelect(components.RichSelect):
+class MySelect(components.RichStringSelect):
 
     placeholder = "Please select a square."  # Set the placeholder text...
     options = SLOT_OPTIONS  # Set the options...

--- a/src/disnake/ext/components/api/component.py
+++ b/src/disnake/ext/components/api/component.py
@@ -182,8 +182,6 @@ class RichSelect(RichComponent, typing.Protocol):
 
     This must lie between 1 and 25, inclusive.
     """
-    options: typing.Collection[typing.Any]
-    """The options the user can choose from."""
     disabled: bool
     """Whether or not this button is disabled.
 

--- a/src/disnake/ext/components/api/component.py
+++ b/src/disnake/ext/components/api/component.py
@@ -189,7 +189,9 @@ class RichSelect(RichComponent, typing.Protocol):
     Disabled selects can therefore not cause any interactions, either.
     """
 
-    async def as_ui_component(self) -> disnake.ui.StringSelect[None]:  # noqa: D102
+    async def as_ui_component(  # noqa: D102
+        self,
+    ) -> disnake.ui.BaseSelect[typing.Any, typing.Any, None]:
         # <<Docstring inherited from RichComponent>>
         ...
 

--- a/src/disnake/ext/components/impl/component/select.py
+++ b/src/disnake/ext/components/impl/component/select.py
@@ -42,7 +42,9 @@ class BaseSelect(
     max_values: int = fields.internal(1)
     disabled: bool = fields.internal(False)  # noqa: FBT003
 
-    async def as_ui_component(self) -> disnake.ui.BaseSelect:  # noqa: D102
+    async def as_ui_component(  # noqa: D102
+        self,
+    ) -> disnake.ui.BaseSelect[typing.Any, typing.Any, None]:
         # <<docstring inherited from component_api.RichButton>>
         ...
 
@@ -215,8 +217,8 @@ class RichChannelSelect(BaseSelect, typing.Protocol):
     This works similar to a dataclass, but with some extra things to take into
     account.
 
-    First and foremost, there are class variables for :attr:`placeholder`,
-    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`.
+    First and foremost, there are class variables for :attr:`channel_types`,
+    :attr:`placeholder`, :attr:`min_values`, :attr:`max_values`, :attr:`disabled`.
     These set the corresponding attributes on the select class when they are
     sent to discord, and are meant to be overwritten by the user.
 
@@ -230,10 +232,13 @@ class RichChannelSelect(BaseSelect, typing.Protocol):
     keyword-only arguments.
     """
 
+    channel_types: typing.Optional[list[disnake.ChannelType]] = fields.internal(None)
+
     async def as_ui_component(self) -> disnake.ui.ChannelSelect[None]:  # noqa: D102
         # <<docstring inherited from component_api.RichButton>>
 
         return disnake.ui.ChannelSelect(
+            channel_types=self.channel_types,
             placeholder=self.placeholder,
             min_values=self.min_values,
             max_values=self.max_values,

--- a/src/disnake/ext/components/impl/component/select.py
+++ b/src/disnake/ext/components/impl/component/select.py
@@ -14,30 +14,21 @@ from disnake.ext.components.impl.component import base as component_base
 if typing.TYPE_CHECKING:
     import typing_extensions
 
+__all__: typing.Sequence[str] = (
+    "RichStringSelect",
+    "RichUserSelect",
+    "RichRoleSelect",
+    "RichMentionableSelect",
+    "RichChannelSelect",
+)
+
 
 class BaseSelect(
     component_api.RichSelect, component_base.ComponentBase, typing.Protocol
 ):
-    """The default implementation of a disnake-ext-components select.
-
-    This works similar to a dataclass, but with some extra things to take into
-    account.
-
-    First and foremost, there are class variables for :attr:`placeholder`,
-    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`, and:attr:`options`
-    (available only when using :class:`RichStringSelect`).
-    These set the corresponding attributes on the select class when they are
-    sent to discord, and are meant to be overwritten by the user.
-
-    Fields can be defined similarly to dataclasses, by means of a name, a type
-    annotation, and an optional :func:`components.field` to set the default or
-    a custom parser. The options field specifically is designated with
-    :func:`components.options` instead.
-
-    Classes created in this way have auto-generated slots and an auto-generated
-    ``__init__``. The init-signature contains all the custom id fields as
-    keyword-only arguments.
-    """
+    """The base class of a disnake-ext-components select. This isn't meant
+    to beused directly.
+    """  # noqa: D205
 
     event = "on_dropdown"
 
@@ -79,12 +70,34 @@ class BaseSelect(
 
 
 class RichStringSelect(BaseSelect, typing.Protocol):
-    """The default implementation of a disnake-ext-components string select."""
+    """The default implementation of a disnake-ext-components string select.
+
+    This works similar to a dataclass, but with some extra things to take into
+    account.
+
+    First and foremost, there are class variables for :attr:`placeholder`,
+    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`, and:attr:`options`
+    (available only when using :class:`RichStringSelect`).
+    These set the corresponding attributes on the select class when they are
+    sent to discord, and are meant to be overwritten by the user.
+
+    Fields can be defined similarly to dataclasses, by means of a name, a type
+    annotation, and an optional :func:`components.field` to set the default or
+    a custom parser. The options field specifically is designated with
+    :func:`components.options` instead.
+
+    Classes created in this way have auto-generated slots and an auto-generated
+    ``__init__``. The init-signature contains all the custom id fields as
+    keyword-only arguments.
+    """
+
     options: list[disnake.SelectOption] = fields.internal(
         attr.Factory(list)  # pyright: ignore
     )
 
-    async def as_ui_component(self) -> disnake.ui.StringSelect[None]:
+    async def as_ui_component(self) -> disnake.ui.StringSelect[None]:  # noqa: D102
+        # <<docstring inherited from component_api.RichButton>>
+
         return disnake.ui.StringSelect(
             placeholder=self.placeholder,
             min_values=self.min_values,
@@ -96,8 +109,29 @@ class RichStringSelect(BaseSelect, typing.Protocol):
 
 
 class RichUserSelect(BaseSelect, typing.Protocol):
-    """The default implementation of a disnake-ext-components user select."""
-    async def as_ui_component(self) -> disnake.ui.UserSelect[None]:
+    """The default implementation of a disnake-ext-components user select.
+
+    This works similar to a dataclass, but with some extra things to take into
+    account.
+
+    First and foremost, there are class variables for :attr:`placeholder`,
+    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`.
+    These set the corresponding attributes on the select class when they are
+    sent to discord, and are meant to be overwritten by the user.
+
+    Fields can be defined similarly to dataclasses, by means of a name, a type
+    annotation, and an optional :func:`components.field` to set the default or
+    a custom parser. The options field specifically is designated with
+    :func:`components.options` instead.
+
+    Classes created in this way have auto-generated slots and an auto-generated
+    ``__init__``. The init-signature contains all the custom id fields as
+    keyword-only arguments.
+    """
+
+    async def as_ui_component(self) -> disnake.ui.UserSelect[None]:  # noqa: D102
+        # <<docstring inherited from component_api.RichButton>>
+
         return disnake.ui.UserSelect(
             placeholder=self.placeholder,
             min_values=self.min_values,
@@ -108,8 +142,29 @@ class RichUserSelect(BaseSelect, typing.Protocol):
 
 
 class RichRoleSelect(BaseSelect, typing.Protocol):
-    """The default implementation of a disnake-ext-components role select."""
-    async def as_ui_component(self) -> disnake.ui.RoleSelect[None]:
+    """The default implementation of a disnake-ext-components role select.
+
+    This works similar to a dataclass, but with some extra things to take into
+    account.
+
+    First and foremost, there are class variables for :attr:`placeholder`,
+    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`.
+    These set the corresponding attributes on the select class when they are
+    sent to discord, and are meant to be overwritten by the user.
+
+    Fields can be defined similarly to dataclasses, by means of a name, a type
+    annotation, and an optional :func:`components.field` to set the default or
+    a custom parser. The options field specifically is designated with
+    :func:`components.options` instead.
+
+    Classes created in this way have auto-generated slots and an auto-generated
+    ``__init__``. The init-signature contains all the custom id fields as
+    keyword-only arguments.
+    """
+
+    async def as_ui_component(self) -> disnake.ui.RoleSelect[None]:  # noqa: D102
+        # <<docstring inherited from component_api.RichButton>>
+
         return disnake.ui.RoleSelect(
             placeholder=self.placeholder,
             min_values=self.min_values,
@@ -120,8 +175,29 @@ class RichRoleSelect(BaseSelect, typing.Protocol):
 
 
 class RichMentionableSelect(BaseSelect, typing.Protocol):
-    """The default implementation of a disnake-ext-components mentionable select."""
-    async def as_ui_component(self) -> disnake.ui.MentionableSelect[None]:
+    """The default implementation of a disnake-ext-components mentionable select.
+
+    This works similar to a dataclass, but with some extra things to take into
+    account.
+
+    First and foremost, there are class variables for :attr:`placeholder`,
+    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`.
+    These set the corresponding attributes on the select class when they are
+    sent to discord, and are meant to be overwritten by the user.
+
+    Fields can be defined similarly to dataclasses, by means of a name, a type
+    annotation, and an optional :func:`components.field` to set the default or
+    a custom parser. The options field specifically is designated with
+    :func:`components.options` instead.
+
+    Classes created in this way have auto-generated slots and an auto-generated
+    ``__init__``. The init-signature contains all the custom id fields as
+    keyword-only arguments.
+    """
+
+    async def as_ui_component(self) -> disnake.ui.MentionableSelect[None]:  # noqa: D102
+        # <<docstring inherited from component_api.RichButton>>
+
         return disnake.ui.MentionableSelect(
             placeholder=self.placeholder,
             min_values=self.min_values,
@@ -132,8 +208,29 @@ class RichMentionableSelect(BaseSelect, typing.Protocol):
 
 
 class RichChannelSelect(BaseSelect, typing.Protocol):
-    """The default implementation of a disnake-ext-components channel select."""
-    async def as_ui_component(self) -> disnake.ui.ChannelSelect[None]:
+    """The default implementation of a disnake-ext-components channel select.
+
+    This works similar to a dataclass, but with some extra things to take into
+    account.
+
+    First and foremost, there are class variables for :attr:`placeholder`,
+    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`.
+    These set the corresponding attributes on the select class when they are
+    sent to discord, and are meant to be overwritten by the user.
+
+    Fields can be defined similarly to dataclasses, by means of a name, a type
+    annotation, and an optional :func:`components.field` to set the default or
+    a custom parser. The options field specifically is designated with
+    :func:`components.options` instead.
+
+    Classes created in this way have auto-generated slots and an auto-generated
+    ``__init__``. The init-signature contains all the custom id fields as
+    keyword-only arguments.
+    """
+
+    async def as_ui_component(self) -> disnake.ui.ChannelSelect[None]:  # noqa: D102
+        # <<docstring inherited from component_api.RichButton>>
+
         return disnake.ui.ChannelSelect(
             placeholder=self.placeholder,
             min_values=self.min_values,

--- a/src/disnake/ext/components/impl/component/select.py
+++ b/src/disnake/ext/components/impl/component/select.py
@@ -15,10 +15,10 @@ if typing.TYPE_CHECKING:
     import typing_extensions
 
 
-class RichSelect(
+class BaseSelect(
     component_api.RichSelect, component_base.ComponentBase, typing.Protocol
 ):
-    """The default implementation of a disnake-ext-components button.
+    """The default implementation of a disnake-ext-components select.
 
     This works similar to a dataclass, but with some extra things to take into
     account.
@@ -46,21 +46,10 @@ class RichSelect(
     min_values: int = fields.internal(1)
     max_values: int = fields.internal(1)
     disabled: bool = fields.internal(False)  # noqa: FBT003
-    options: list[disnake.SelectOption] = fields.internal(
-        attr.Factory(list)  # pyright: ignore
-    )
 
-    async def as_ui_component(self) -> disnake.ui.StringSelect[None]:  # noqa: D102
+    async def as_ui_component(self) -> disnake.ui.BaseSelect:  # noqa: D102
         # <<docstring inherited from component_api.RichButton>>
-
-        return disnake.ui.StringSelect(
-            placeholder=self.placeholder,
-            min_values=self.min_values,
-            max_values=self.max_values,
-            disabled=self.disabled,
-            options=self.options,
-            custom_id=await self.dumps(),
-        )
+        ...
 
     @classmethod
     async def loads(  # noqa: D102
@@ -86,3 +75,63 @@ class RichSelect(
         # NOTE: We narrow the interaction type down to a disnake.MessageInteraction
         #       here. This isn't typesafe, but it's just cleaner for the user.
         ...
+
+
+class RichStringSelect(BaseSelect, typing.Protocol):
+    options: list[disnake.SelectOption] = fields.internal(
+        attr.Factory(list)  # pyright: ignore
+    )
+
+    async def as_ui_component(self) -> disnake.ui.StringSelect[None]:
+        return disnake.ui.StringSelect(
+            placeholder=self.placeholder,
+            min_values=self.min_values,
+            max_values=self.max_values,
+            disabled=self.disabled,
+            options=self.options,
+            custom_id=await self.dumps(),
+        )
+
+
+class RichUserSelect(BaseSelect, typing.Protocol):
+    async def as_ui_component(self) -> disnake.ui.UserSelect[None]:
+        return disnake.ui.UserSelect(
+            placeholder=self.placeholder,
+            min_values=self.min_values,
+            max_values=self.max_values,
+            disabled=self.disabled,
+            custom_id=await self.dumps(),
+        )
+
+
+class RichRoleSelect(BaseSelect, typing.Protocol):
+    async def as_ui_component(self) -> disnake.ui.RoleSelect[None]:
+        return disnake.ui.RoleSelect(
+            placeholder=self.placeholder,
+            min_values=self.min_values,
+            max_values=self.max_values,
+            disabled=self.disabled,
+            custom_id=await self.dumps(),
+        )
+
+
+class RichMentionableSelect(BaseSelect, typing.Protocol):
+    async def as_ui_component(self) -> disnake.ui.MentionableSelect[None]:
+        return disnake.ui.MentionableSelect(
+            placeholder=self.placeholder,
+            min_values=self.min_values,
+            max_values=self.max_values,
+            disabled=self.disabled,
+            custom_id=await self.dumps(),
+        )
+
+
+class RichChannelSelect(BaseSelect, typing.Protocol):
+    async def as_ui_component(self) -> disnake.ui.ChannelSelect[None]:
+        return disnake.ui.ChannelSelect(
+            placeholder=self.placeholder,
+            min_values=self.min_values,
+            max_values=self.max_values,
+            disabled=self.disabled,
+            custom_id=await self.dumps(),
+        )

--- a/src/disnake/ext/components/impl/component/select.py
+++ b/src/disnake/ext/components/impl/component/select.py
@@ -26,9 +26,12 @@ __all__: typing.Sequence[str] = (
 class BaseSelect(
     component_api.RichSelect, component_base.ComponentBase, typing.Protocol
 ):
-    """The base class of a disnake-ext-components select. This isn't meant
-    to beused directly.
-    """  # noqa: D205
+    """The base class of a disnake-ext-components selects.
+
+    For implementations, see :class:`RichStringSelect`, :class:`RichUserSelect`,
+    :class:`RichRoleSelect`, :class:`RichMentionableSelect`,
+    :class:`RichChannelSelect`.
+    """
 
     event = "on_dropdown"
 
@@ -76,8 +79,7 @@ class RichStringSelect(BaseSelect, typing.Protocol):
     account.
 
     First and foremost, there are class variables for :attr:`placeholder`,
-    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`, and:attr:`options`
-    (available only when using :class:`RichStringSelect`).
+    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`, and:attr:`options`.
     These set the corresponding attributes on the select class when they are
     sent to discord, and are meant to be overwritten by the user.
 

--- a/src/disnake/ext/components/impl/component/select.py
+++ b/src/disnake/ext/components/impl/component/select.py
@@ -42,12 +42,6 @@ class BaseSelect(
     max_values: int = fields.internal(1)
     disabled: bool = fields.internal(False)  # noqa: FBT003
 
-    async def as_ui_component(  # noqa: D102
-        self,
-    ) -> disnake.ui.BaseSelect[typing.Any, typing.Any, None]:
-        # <<docstring inherited from component_api.RichButton>>
-        ...
-
     @classmethod
     async def loads(  # noqa: D102
         cls, interaction: disnake.MessageInteraction, /

--- a/src/disnake/ext/components/impl/component/select.py
+++ b/src/disnake/ext/components/impl/component/select.py
@@ -24,7 +24,8 @@ class BaseSelect(
     account.
 
     First and foremost, there are class variables for :attr:`placeholder`,
-    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`, and :attr:`options`.
+    :attr:`min_values`, :attr:`max_values`, :attr:`disabled`, and:attr:`options`
+    (available only when using :class:`RichStringSelect`).
     These set the corresponding attributes on the select class when they are
     sent to discord, and are meant to be overwritten by the user.
 
@@ -78,6 +79,7 @@ class BaseSelect(
 
 
 class RichStringSelect(BaseSelect, typing.Protocol):
+    """The default implementation of a disnake-ext-components string select."""
     options: list[disnake.SelectOption] = fields.internal(
         attr.Factory(list)  # pyright: ignore
     )
@@ -94,6 +96,7 @@ class RichStringSelect(BaseSelect, typing.Protocol):
 
 
 class RichUserSelect(BaseSelect, typing.Protocol):
+    """The default implementation of a disnake-ext-components user select."""
     async def as_ui_component(self) -> disnake.ui.UserSelect[None]:
         return disnake.ui.UserSelect(
             placeholder=self.placeholder,
@@ -105,6 +108,7 @@ class RichUserSelect(BaseSelect, typing.Protocol):
 
 
 class RichRoleSelect(BaseSelect, typing.Protocol):
+    """The default implementation of a disnake-ext-components role select."""
     async def as_ui_component(self) -> disnake.ui.RoleSelect[None]:
         return disnake.ui.RoleSelect(
             placeholder=self.placeholder,
@@ -116,6 +120,7 @@ class RichRoleSelect(BaseSelect, typing.Protocol):
 
 
 class RichMentionableSelect(BaseSelect, typing.Protocol):
+    """The default implementation of a disnake-ext-components mentionable select."""
     async def as_ui_component(self) -> disnake.ui.MentionableSelect[None]:
         return disnake.ui.MentionableSelect(
             placeholder=self.placeholder,
@@ -127,6 +132,7 @@ class RichMentionableSelect(BaseSelect, typing.Protocol):
 
 
 class RichChannelSelect(BaseSelect, typing.Protocol):
+    """The default implementation of a disnake-ext-components channel select."""
     async def as_ui_component(self) -> disnake.ui.ChannelSelect[None]:
         return disnake.ui.ChannelSelect(
             placeholder=self.placeholder,

--- a/src/disnake/ext/components/interaction.py
+++ b/src/disnake/ext/components/interaction.py
@@ -47,7 +47,7 @@ async def _prepare(component: MessageComponents) -> disnake.ui.MessageUIComponen
     if isinstance(
         component, (component_api.RichButton, component_api.RichSelect)
     ):  # TODO: add select
-        return await component.as_ui_component()  # type: ignore[reportGeneralTypeIssues]  # noqa: E501
+        return await component.as_ui_component()  # pyright: ignore
 
     return component
 

--- a/src/disnake/ext/components/interaction.py
+++ b/src/disnake/ext/components/interaction.py
@@ -32,7 +32,11 @@ MessageComponents = typing.Union[
     component_api.RichButton,
     disnake.ui.Button[typing.Any],
     component_api.RichSelect,
-    disnake.ui.Select[typing.Any],
+    disnake.ui.StringSelect[typing.Any],
+    disnake.ui.ChannelSelect[typing.Any],
+    disnake.ui.RoleSelect[typing.Any],
+    disnake.ui.UserSelect[typing.Any],
+    disnake.ui.MentionableSelect[typing.Any],
 ]
 
 
@@ -43,7 +47,7 @@ async def _prepare(component: MessageComponents) -> disnake.ui.MessageUIComponen
     if isinstance(
         component, (component_api.RichButton, component_api.RichSelect)
     ):  # TODO: add select
-        return await component.as_ui_component()
+        return await component.as_ui_component()  # type: ignore[reportGeneralTypeIssues]  # noqa: E501
 
     return component
 


### PR DESCRIPTION
This PR implements all available select types:

- ui.StringSelect
- ui.UserSelect
- ui.RoleSelect
- ui.ChannelSelect
- ui.MentionableSelect

`RichSelect` was renamed to `BaseSelect` and is now the base class for every `Rich<Type>Select` class

TODO:

- [x] add docstrings