### PR TITLE
Feat/all the parsers

### DIFF
--- a/examples/attrs.py
+++ b/examples/attrs.py
@@ -17,7 +17,7 @@ from disnake.ext import commands, components
 
 # First and foremost, we create a bot as per usual. Since we don't need any
 # prefix command capabilities, we opt for an InteractionBot.
-bot = commands.InteractionBot(sync_commands_debug=True)
+bot = commands.InteractionBot()
 
 # Next, we make a component manager and register it to the bot.
 manager = components.get_manager()

--- a/examples/button.py
+++ b/examples/button.py
@@ -35,7 +35,7 @@ async def test_button(inter: disnake.CommandInteraction) -> None:
     wrapped = components.wrap_interaction(inter)
     component = MyButton(count=0)
 
-    await wrapped.send(components=component)
+    await wrapped.response.send_message(components=component)
 
     # If we had not wrapped the interaction, we would have needed to do
     # `await inter.send(components=await component.as_ui_component())`

--- a/examples/detail.py
+++ b/examples/detail.py
@@ -1,0 +1,80 @@
+"""An example showcasing how attrs utilities can be used with ext-components."""
+
+import os
+
+import disnake
+from disnake.ext import commands, components
+
+# Say we wish to create a component, but we do not know the number of options
+# beforehand, and we would like the user to be able to select all of them. It
+# can be cumbersome to manually keep updating the `max_values` parameter of the
+# select. Luckily, with the knowledge that ext-components is built upon the
+# `attrs` lib, a few options become available to us.
+# For this example, we will be making use of attrs classes' __attrs_post_init__
+# method, which is called immediately after attrs finishes its normal
+# initialisation logic. If you're familiar with dataclasses, this is essentially
+# the same as a dataclass' __post_init__ method.
+
+# First and foremost, we create a bot as per usual. Since we don't need any
+# prefix command capabilities, we opt for an InteractionBot.
+bot = commands.InteractionBot(sync_commands_debug=True)
+
+# Next, we make a component manager and register it to the bot.
+manager = components.get_manager()
+manager.add_to_bot(bot)
+
+
+@manager.register
+class CustomisableSelect(components.RichStringSelect):
+    # Now, we ensure that max_values adapts to the passed number of options.
+    # Since rich components use attrs under the hood, this can easily be
+    # achieved through the __attrs_post_init__ method.
+    def __attrs_post_init__(self) -> None:
+        self.max_values = len(self.options)
+
+    async def callback(self, interaction: components.MessageInteraction) -> None:
+        selection = (
+            "\n".join(f"- {value}" for value in interaction.values)
+            if interaction.values
+            else "nothing :("
+        )
+
+        await interaction.response.send_message(
+            f"You selected:\n{selection}", ephemeral=True
+        )
+
+
+@bot.slash_command()  # pyright: ignore
+async def make_select(interaction: disnake.CommandInteraction, options: str) -> None:
+    """Make your own select menu.
+
+    Parameters
+    ----------
+    options:
+        A comma-separated string with all options. Max 25.
+    """
+    # If the string is empty or whitespace, the user did not provide options.
+    if not options.strip():
+        await interaction.response.send_message("You must specify at least one option!")
+        return
+
+    # Next, we make the options by splitting over commas.
+    actual_options = [
+        disnake.SelectOption(label=option.strip())
+        for option in options.split(",")
+    ]  # fmt: skip
+
+    # Before creating the component, validate that there's max 25 options.
+    if len(actual_options) > 25:
+        await interaction.response.send_message("You must specify at most 25 options!")
+        return
+
+    # If everything went correctly, we send the component.
+    wrapped = components.wrap_interaction(interaction)
+    await wrapped.response.send_message(
+        components=CustomisableSelect(options=actual_options),
+    )
+
+
+# Lastly, we run the bot.
+bot.run(os.getenv("EXAMPLE_TOKEN"))

--- a/examples/manager.py
+++ b/examples/manager.py
@@ -165,7 +165,7 @@ async def test_button(inter: disnake.CommandInteraction) -> None:
     wrapped = components.wrap_interaction(inter)
     component = FooButton(count=0)
 
-    await wrapped.send(components=component)
+    await wrapped.response.send_message(components=component)
 
 
 @bot.slash_command()  # pyright: ignore  # still some unknowns in disnake
@@ -173,7 +173,7 @@ async def test_nested_button(inter: disnake.CommandInteraction) -> None:
     wrapped = components.wrap_interaction(inter)
     component = FooBarBazButton(count=0)
 
-    await wrapped.send(components=component)
+    await wrapped.response.send_message(components=component)
 
 
 # Lastly, we run the bot.

--- a/examples/select.py
+++ b/examples/select.py
@@ -124,7 +124,9 @@ async def test_select(inter: disnake.CommandInteraction) -> None:
     wrapped = components.wrap_interaction(inter)
 
     component = MySelect()
-    await wrapped.send(component.render_colours(), components=component)
+    await wrapped.response.send_message(
+        component.render_colours(), components=component
+    )
 
     # If we had not wrapped the interaction, we would have needed to do
     # `await inter.send(components=await component.as_ui_component())`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ slotscheck = "^0.16.5"
 pre-commit = "^3.1.1"
 taskipy = "^1.10.3"
 python-dotenv = "^1.0.0"
+ipykernel = "^6.23.3"
 
 
 [tool.poetry.scripts]
@@ -136,6 +137,7 @@ mypy-init-return = true
     "D101",
     "D102",
     "D103",
+    "D417",
     "S101",
     "TCH",
     "T201",

--- a/src/disnake/ext/components/impl/__init__.py
+++ b/src/disnake/ext/components/impl/__init__.py
@@ -4,7 +4,7 @@
 
 """Default concrete implementations for types in ``disnake.ext.components.api``."""
 
+from disnake.ext.components.impl import parser as parser
 from disnake.ext.components.impl.component import *
 from disnake.ext.components.impl.factory import *
 from disnake.ext.components.impl.manager import *
-from disnake.ext.components.impl.parser import *

--- a/src/disnake/ext/components/impl/component/base.py
+++ b/src/disnake/ext/components/impl/component/base.py
@@ -62,8 +62,7 @@ def _determine_parser(
             return parser
 
     if required:
-        parser_type = parser_impl.get_parser(attribute.type or str)
-        return parser_type.default()
+        return parser_impl.get_parser(attribute.type or str)
 
     return None
 

--- a/src/disnake/ext/components/impl/parser/__init__.py
+++ b/src/disnake/ext/components/impl/parser/__init__.py
@@ -7,6 +7,7 @@
 from disnake.ext.components.impl.parser.base import *
 from disnake.ext.components.impl.parser.channel import *
 from disnake.ext.components.impl.parser.emoji import *
+from disnake.ext.components.impl.parser.enum import *
 from disnake.ext.components.impl.parser.guild import *
 from disnake.ext.components.impl.parser.invite import *
 from disnake.ext.components.impl.parser.message import *

--- a/src/disnake/ext/components/impl/parser/__init__.py
+++ b/src/disnake/ext/components/impl/parser/__init__.py
@@ -6,5 +6,12 @@
 
 from disnake.ext.components.impl.parser.base import *
 from disnake.ext.components.impl.parser.channel import *
+from disnake.ext.components.impl.parser.emoji import *
+from disnake.ext.components.impl.parser.guild import *
+from disnake.ext.components.impl.parser.invite import *
+from disnake.ext.components.impl.parser.message import *
+from disnake.ext.components.impl.parser.permissions import *
+from disnake.ext.components.impl.parser.role import *
 from disnake.ext.components.impl.parser.snowflake import *
 from disnake.ext.components.impl.parser.stdlib import *
+from disnake.ext.components.impl.parser.user import *

--- a/src/disnake/ext/components/impl/parser/base.py
+++ b/src/disnake/ext/components/impl/parser/base.py
@@ -32,33 +32,14 @@ TypeSequence = typing.Sequence[typing.Type[typing.Any]]
 def _issubclass(
     cls: type, class_or_tuple: typing.Union[type, typing.Tuple[type, ...]]
 ) -> bool:
-    """Specialised issubclass that works with protocols with non-method members.
+    try:
+        return issubclass(cls, class_or_tuple)
 
-    Doing this isn't entirely correct, but we need to do it to support
-    types such as ``disnake.abc.Snowflake``.
-    """
-    attr: str
+    except TypeError:
+        if isinstance(class_or_tuple, tuple):
+            return any(cls is cls_ for cls_ in class_or_tuple)
 
-    if not isinstance(class_or_tuple, tuple):
-        class_or_tuple = (class_or_tuple,)
-
-    for class_ in class_or_tuple:
-        try:
-            if issubclass(cls, class_):
-                return True
-
-        except TypeError:
-            if not getattr(class_, "_is_protocol", False):
-                raise
-
-            # HACK: This may break with typing updates!
-            for attr in typing._get_protocol_attrs(class_):  # pyright: ignore
-                if not hasattr(cls, attr):
-                    return False
-
-            return True
-
-    return False
+        return cls is class_or_tuple
 
 
 def register_parser(

--- a/src/disnake/ext/components/impl/parser/enum.py
+++ b/src/disnake/ext/components/impl/parser/enum.py
@@ -1,0 +1,77 @@
+"""Parser implementations for standard library and disnake enums and flags."""
+
+import enum
+import typing
+
+import disnake
+from disnake.ext.components.impl.parser import base as parser_base
+from disnake.ext.components.internal import aio
+
+__all__: typing.Sequence[str] = ("EnumParser", "FlagParser")
+
+_EnumT = typing.TypeVar("_EnumT", bound=typing.Union[enum.Enum, disnake.Enum])
+
+
+def _get_enum_type(
+    enum_class: type[typing.Union[enum.Enum, disnake.flags.BaseFlags]]
+) -> type:
+    maybe_type = getattr(enum_class, "_member_type_", object)
+    if maybe_type is not object:
+        return maybe_type
+
+    # Get first member's type
+    member_iter = iter(disnake.ActivityType)
+    maybe_type = type(next(member_iter).value)
+
+    # If all members match this type, return it.
+    if all(type(member.value) == maybe_type for member in member_iter):
+        return maybe_type
+
+    # No concrete type, throw hands.
+    msg = "Cannot parse enums with more than one value type."
+    raise TypeError(msg)
+
+
+class EnumParser(
+    parser_base.Parser[_EnumT],
+    is_default_for=(enum.Enum, disnake.Enum, enum.Flag, disnake.flags.BaseFlags),
+):
+    """Parser type for enums and flags.
+
+    Enums and flags are stored by value instead of by name. This makes parsing
+    a bit slower, but values are generally shorter than names.
+
+    This parser type works for standard library and disnake enums and flags.
+    Note that this only works for enums and flags where all values are of the
+    same type.
+
+    Parameters
+    ----------
+    enum_class:
+        The enum or flag class to use for parsing.
+    """
+
+    enum_class: type[_EnumT]
+    value_parser: parser_base.Parser[typing.Any]
+
+    def __init__(self, enum_class: type[_EnumT]) -> None:
+        self.enum_class = enum_class
+        self.value_parser = parser_base.get_parser(_get_enum_type(enum_class))
+
+    async def loads(  # noqa: D102
+        self, interaction: disnake.Interaction, argument: str
+    ) -> _EnumT:
+        # <<docstring inherited from parser_api.Parser>>
+
+        parsed = await aio.eval_maybe_coro(
+            self.value_parser.loads(interaction, argument)
+        )
+        return self.enum_class(parsed)
+
+    def dumps(self, argument: _EnumT) -> parser_base.MaybeCoroutine[str]:  # noqa: D102
+        # <<docstring inherited from parser_api.Parser>>
+
+        return self.value_parser.dumps(argument.value)
+
+
+FlagParser = EnumParser

--- a/src/disnake/ext/components/impl/parser/enum.py
+++ b/src/disnake/ext/components/impl/parser/enum.py
@@ -13,7 +13,7 @@ _EnumT = typing.TypeVar("_EnumT", bound=typing.Union[enum.Enum, disnake.Enum])
 
 
 def _get_enum_type(
-    enum_class: type[typing.Union[enum.Enum, disnake.flags.BaseFlags]]
+    enum_class: typing.Type[typing.Union[enum.Enum, disnake.flags.BaseFlags]]
 ) -> type:
     maybe_type = getattr(enum_class, "_member_type_", object)
     if maybe_type is not object:
@@ -51,10 +51,10 @@ class EnumParser(
         The enum or flag class to use for parsing.
     """
 
-    enum_class: type[_EnumT]
+    enum_class: typing.Type[_EnumT]
     value_parser: parser_base.Parser[typing.Any]
 
-    def __init__(self, enum_class: type[_EnumT]) -> None:
+    def __init__(self, enum_class: typing.Type[_EnumT]) -> None:
         self.enum_class = enum_class
         self.value_parser = parser_base.get_parser(_get_enum_type(enum_class))
 

--- a/src/disnake/ext/components/impl/parser/stdlib.py
+++ b/src/disnake/ext/components/impl/parser/stdlib.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import datetime
-import enum  # Safe import, disnake imports this anyways.
+import enum
+import inspect
 import typing
 
+import disnake.utils
 import typing_extensions
 from disnake.ext.components.impl.parser import base
+from disnake.ext.components.internal import aio
 
 if typing.TYPE_CHECKING:
     import disnake
@@ -23,11 +26,18 @@ __all__: typing.Sequence[str] = (
     "TimeParser",
     "TimedeltaParser",
     "TimezoneParser",
+    "CollectionParser",
+    "TupleParser",
 )
 
 
 _NumberT = typing_extensions.TypeVar("_NumberT", bound=float, default=float)
-
+_CollectionT = typing_extensions.TypeVar(  # Simplest iterable container object.
+    "_CollectionT", bound=typing.Collection[object], default=typing.Collection[str]
+)
+_UnpackInnerT = typing_extensions.TypeVarTuple(
+    "_UnpackInnerT", default=typing_extensions.Unpack[typing.Tuple[str]]
+)
 
 # INT / FLOAT
 
@@ -333,3 +343,157 @@ TimezoneParser = base.Parser.from_funcs(
     lambda arg: dumps_float(arg.utcoffset(None).total_seconds()),
     is_default_for=(datetime.timezone,),
 )
+
+
+def _resolve_collection(type_: typing.Type[_CollectionT]) -> typing.Type[_CollectionT]:
+    # ContainerParser itself does not support tuples.
+    if issubclass(type_, typing.Tuple):
+        msg = (
+            f"{CollectionParser.__name__}s do not support tuples. Please use a "
+            f"{TupleParser.__name__} instead."
+        )
+        raise TypeError(msg)
+
+    if not getattr(type_, "_is_protocol", False) and not inspect.isabstract(type_):
+        # Concrete type, return as-is.
+        return type_
+
+    # Try to resolve an abstract type to a valid concrete structural subtype.
+    if issubclass(type_, typing.Sequence):
+        return typing.cast(typing.Type[_CollectionT], list)
+
+    elif issubclass(type_, typing.AbstractSet):
+        return typing.cast(typing.Type[_CollectionT], set)
+
+    msg = f"Cannot infer a concrete type for abstract type {type_.__name__!r}."
+    raise TypeError(msg)
+
+
+class CollectionParser(base.Parser[_CollectionT]):
+    """Parser type with support for collections of other types.
+
+    This parser parses a string into a given container type and inner type, and
+    vice versa.
+
+    Note that this parser does not support tuples.
+
+    Parameters
+    ----------
+    inner_parser: components.Parser[object]
+        The parser to use to parse the items inside the collection. This defines
+        the inner type for the collection. Sadly, due to typing restrictions,
+        this is not enforced during type-checking. Defaults to a string parser.
+    collection_type: Collection[object]
+        The type of collection to use. This does not specify the inner type.
+    sep: str
+        The separator to use. Can be any string, though a single character is
+        recommended. Defaults to ",".
+    """
+
+    inner_parser: base.Parser[typing.Any]
+    collection_type: typing.Type[_CollectionT]
+    sep: str
+
+    def __init__(
+        self,
+        inner_parser: typing.Optional[base.Parser[typing.Any]] = None,
+        *,
+        collection_type: typing.Optional[typing.Type[_CollectionT]] = None,
+        sep: str = ",",
+    ) -> None:
+        self.sep = sep
+        self.collection_type = typing.cast(  # Pyright do be whack sometimes.
+            typing.Type[_CollectionT],
+            list if collection_type is None else _resolve_collection(collection_type),
+        )
+        self.inner_parser = (
+            StringParser.default() if inner_parser is None else inner_parser
+        )
+
+    async def loads(  # noqa: D102
+        self, interaction: disnake.Interaction, argument: str
+    ) -> _CollectionT:
+        # <<docstring inherited from parser_api.Parser>>
+        parsed = [
+            await aio.eval_maybe_coro(self.inner_parser.loads(interaction, part))
+            for part in argument.split(self.sep)
+            if not part.isspace()
+        ]
+
+        return self.collection_type(parsed)  # pyright: ignore
+
+    async def dumps(self, argument: _CollectionT) -> str:  # noqa: D102
+        # <<docstring inherited from parser_api.Parser>>
+        return ",".join(
+            [
+                await aio.eval_maybe_coro(self.inner_parser.dumps(part))
+                for part in argument
+            ]
+        )
+
+
+class TupleParser(
+    base.Parser[typing.Tuple[typing_extensions.Unpack[_UnpackInnerT]]],
+    typing.Generic[typing_extensions.Unpack[_UnpackInnerT]],
+):
+    """Parser type with support for tuples.
+
+    The benefit of a tuple parser is fixed-length checks and the ability to set
+    multiple types. For example, a ``Tuple[str, int, bool]`` parser will
+    actually return a tuple with a ``str``, ``int``, and ``bool`` inside.
+
+    Parameters
+    ----------
+    *inner_parsers: components.Parser[object]
+        The parsers to use to parse the items inside the tuple. These define
+        the inner types and the allowed number of items in the in the tuple.
+    sep: str
+        The separator to use. Can be any string, though a single character is
+        recommended. Defaults to ",".
+    """
+
+    inner_parsers: typing.Tuple[base.Parser[typing.Any]]
+    sep: str
+
+    def __init__(
+        self,
+        *inner_parsers: base.Parser[typing.Any],
+        sep: str = ",",
+    ) -> None:
+        self.inner_parsers = inner_parsers if inner_parsers else (StringParser(),)
+        self.sep = sep
+
+    async def loads(  # noqa: D102
+        self, interaction: disnake.Interaction, argument: str
+    ) -> typing.Tuple[typing_extensions.Unpack[_UnpackInnerT]]:
+        # <<docstring inherited from parser_api.Parser>>
+        parts = argument.split(self.sep)
+
+        if len(parts) != len(self.inner_parsers):
+            msg = f"Expected {len(self.inner_parsers)} arguments, got {len(parts)}."
+            raise RuntimeError(msg)
+
+        return typing.cast(
+            typing.Tuple[typing_extensions.Unpack[_UnpackInnerT]],
+            tuple(
+                [
+                    await aio.eval_maybe_coro(parser.loads(interaction, part))
+                    for parser, part in zip(self.inner_parsers, parts)
+                ]
+            ),
+        )
+
+    async def dumps(  # noqa: D102
+        self, argument: typing.Tuple[typing_extensions.Unpack[_UnpackInnerT]]
+    ) -> str:
+        # <<docstring inherited from parser_api.Parser>>
+        if len(argument) != len(self.inner_parsers):
+            msg = f"Expected {len(self.inner_parsers)} arguments, got {len(argument)}."
+            raise RuntimeError(msg)
+
+        return self.sep.join(
+            [
+                await aio.eval_maybe_coro(parser.dumps(part))
+                for parser, part in zip(self.inner_parsers, argument)
+            ]
+        )

--- a/src/disnake/ext/components/impl/parser/stdlib.py
+++ b/src/disnake/ext/components/impl/parser/stdlib.py
@@ -46,10 +46,7 @@ _UnpackInnerT = typing_extensions.TypeVarTuple(
 # NONE
 
 
-class NoneParser(
-    base.Parser[None],
-    is_default_for=typing.cast(typing.Tuple[typing.Type[None], ...], _NONES),
-):
+class NoneParser(base.Parser[None], is_default_for=(_NoneType,)):
     """Base parser for None.
 
     Mainly relevant Optional[...] parsers.
@@ -567,7 +564,7 @@ class UnionParser(
 
     Parameters
     ----------
-    *inner_parsers: components.Parser[object]
+    *inner_parsers: Optional[components.Parser[object]]
         The parsers with which to sequentially try to parse the argument.
         None can be provided as one of the parameters to make it optional.
     """

--- a/src/disnake/ext/components/impl/parser/user.py
+++ b/src/disnake/ext/components/impl/parser/user.py
@@ -42,7 +42,9 @@ def _get_member(inter: disnake.Interaction, argument: str) -> disnake.Member:
 
 
 GetUserParser = base.Parser.from_funcs(
-    _get_user, snowflake.snowflake_dumps, is_default_for=(disnake.User,)
+    _get_user,
+    snowflake.snowflake_dumps,
+    is_default_for=(disnake.User, disnake.abc.User),
 )
 GetMemberParser = base.Parser.from_funcs(
     _get_member, snowflake.snowflake_dumps, is_default_for=(disnake.Member,)
@@ -70,7 +72,9 @@ async def _fetch_member(inter: disnake.Interaction, argument: str) -> disnake.Me
 
 
 UserParser = base.Parser.from_funcs(
-    _fetch_user, snowflake.snowflake_dumps, is_default_for=(disnake.User,)
+    _fetch_user,
+    snowflake.snowflake_dumps,
+    is_default_for=(disnake.User, disnake.abc.User),
 )
 MemberParser = base.Parser.from_funcs(
     _fetch_member, snowflake.snowflake_dumps, is_default_for=(disnake.Member,)


### PR DESCRIPTION
Closes #9 

This PR adds support for the parsing of collections (except `Mapping`s) and unions (and therefore also `Optional`).

For example, the following fields are all valid after this PR is merged:
```py
class Foo(RichButton):
    a: list[str]
    b: typing.Sequence[int]
    c: tuple[int, str, disnake.User]
    d: typing.Union[disnake.Channel, int]
    e: typing.Optional[float]
```
Note: the example is not exhaustive.

TODO:
~~- automatically create collection/union parsers from typehints.~~