### PR TITLE
fix: remove modal name prefix from `custom_id` of fields

### DIFF
--- a/disnake_ext_components/listener.py
+++ b/disnake_ext_components/listener.py
@@ -619,7 +619,7 @@ class ModalListener(abc.BaseListener[P, T, disnake.ModalInteraction]):
 
         self.params = [params.ParamInfo.from_param(param) for param in listener_params]
         self.modal_params = [params.ParamInfo.from_param(param) for param in special_params]
-        self.field_ids = [f"{self.__name__}{self.sep}{param.name}" for param in special_params]
+        self.field_ids = [param.name for param in special_params]
 
     async def __call__(  # pyright: ignore
         self,


### PR DESCRIPTION
Modals didn't work if the `custom_id` of all fields was not prefixed with the modal name